### PR TITLE
feat: Dockerfile + .dockerignore API Express

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log*
+.env
+.git
+.gitignore
+README.md

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -42,7 +42,7 @@ app.get('/', (req, res) => {
 
 app.use('/api/restaurants', restaurantRoutes);
 app.use('/api/plats', platRoutes);
-app.use ('/api/commandes ', commandeRoutes ) ;
+app.use ('/api/commandes', commandeRoutes) ;
 
 
 // --- Gestion des erreurs ---


### PR DESCRIPTION
## feat: Dockerfile + .dockerignore API Express

Closes #40 

### Ce qui a été fait

Ajout de la conteneurisation de l'API Express TerrangaFood.

- `api/Dockerfile` : image basée sur `node:20-alpine`, copie optimisée des dépendances avant le code source pour profiter du cache Docker, exposition du port 3001
- `api/.dockerignore` : exclusion de `node_modules`, `.env`, `.git` et des logs pour alléger l'image

### Test effectué

```bash
cd api
docker build -t terrangafood-api .
docker images terrangafood-api
```

Image construite avec succès — taille : ~224 Mo

### Remarques

L'image utilise `node:20-alpine` (~130 Mo) à la place de `node:20` (~1 Go) pour rester légère. La commande de démarrage est `node src/app.js`.